### PR TITLE
Feature/add retry for mpv socket conn

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+### Added
+
+- Added a retry mechanism for the mpv socket connection using an exponential backoff. That way we are sure that mpv is ready to accept connections when creating the ipcclient.
+
 ## [v0.2.2] - 04/08/2022
 
 ## Added

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -117,6 +118,10 @@ func ui() {
 	} else if stat.IsDir() {
 		fmt.Printf("Looks like this is a directory: %q\n", trackFilePath)
 		os.Exit(1)
+	}
+	err = player.Init()
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	p := tea.NewProgram(tui.InitialModel(player, stations, volume, trackFilePath), tea.WithAltScreen())


### PR DESCRIPTION

### Added

- Added a retry mechanism for the mpv socket connection using an exponential backoff. That way we are sure that mpv is ready to accept connections when creating the ipcclient.
