### PR TITLE
Release version v0.2.3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
-## Unreleased
+## [v0.2.3] - 13/11/2022
 
 ### Added
 
@@ -121,6 +121,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 [unreleased]: https://github.com/slashformotion/radioboat/blob/master/changelog.md#unreleased
+[v0.2.3]: https://github.com/slashformotion/radioboat/blob/v0.2.2/changelog.md#unreleased
 [v0.2.2]: https://github.com/slashformotion/radioboat/blob/v0.2.2/changelog.md#unreleased
 [v0.2.1]: https://github.com/slashformotion/radioboat/blob/v0.2.1/changelog.md#unreleased
 [v0.2.0]: https://github.com/slashformotion/radioboat/blob/v0.2.0/changelog.md#unreleased


### PR DESCRIPTION
### Added

- Added a retry mechanism for the mpv socket connection using an exponential backoff. That way we are sure that mpv is ready to accept connections when creating the ipcclient.
- Added a linter in CI.
- Now the station list is responsive. The user can use the arrows or hjkl to navigate.
- Add keybinding to show more keybindings.

### Changed

- Now exit if the editor can't start properly on edit command.
- Changed CI to run in parallel.

### Fixed

- Fix a bug where the last char of the track title was missing.