### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
     branches: [ '**' ]
 
+permissions:
+  contents: read
+
 jobs:
 
   check-style:


### PR DESCRIPTION
Potential fix for [https://github.com/slashformotion/radioboat/security/code-scanning/5](https://github.com/slashformotion/radioboat/security/code-scanning/5)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege token access by default.

Best fix here: define workflow-level:

- `permissions:`
  - `contents: read`

This is the minimal explicit permission needed for `actions/checkout` and read-only repository access used by build/test jobs. It avoids granting write scopes and preserves current behavior.

Change location: in `.github/workflows/ci.yml`, insert the block between the `on:` section and `jobs:` section (after line 10 in the snippet).

No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
